### PR TITLE
[Xlib] Remove stale X lock file on container restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ services:
 
 After initiating the Docker container, you may access the VNC interface by navigating to `https://localhost:8080/vnc.html`.
 
-If you want simpler VNC interface you may use `https://localhost:8080/vnc_lite.html`.
+If you want simpler VNC interface you may use `https://localhost:8080/vnc_lite.html?scale=true`.
 
 ### Volumes
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,3 +18,4 @@ services:
       - DISPLAY_DEPTH=16
       - NOVNC_PORT=8080
       - LOG_LEVEL=CALL
+      #- TZ=America/New_York

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -23,7 +23,7 @@ SETTINGS_PATH="${WORKING_DIR}/settings.json"
 
 # Create symlinks for data files only if they don't already exist
 if [ ! -e "${COOKIES_PATH}" ]; then
-  log "Creating symlinks for cookies.jar"
+  log "Creating symlink for cookies.jar"
   ln -s "${DATA_DIR}/cookies.jar" "${COOKIES_PATH}" || {
     log "Failed to create symlink for cookies.jar"
     exit 1
@@ -31,7 +31,11 @@ if [ ! -e "${COOKIES_PATH}" ]; then
 fi
 
 if [ ! -e "${SETTINGS_PATH}" ]; then
-  ln -s "${DATA_DIR}/settings.json" "${SETTINGS_PATH}"
+  log "Creating symlink for settings.json"
+  ln -s "${DATA_DIR}/settings.json" "${SETTINGS_PATH}" || {
+    log "Failed to create symlink for settings.json"
+    exit 1
+  }
 fi
 
 # Set default values for environment variables
@@ -68,6 +72,13 @@ convert_log_level_to_verbosity() {
 }
 
 VERBOSITY=$(convert_log_level_to_verbosity)
+
+# Clean up any stale X lock file to allow restarts
+if [ -f /tmp/.X0-lock ]; then
+  log "Removing stale X lock file"
+  rm -f /tmp/.X0-lock
+  sleep 1
+fi
 
 # Define output redirection based on LOG_LEVEL
 if [ "$LOG_LEVEL" = "DEBUG" ]; then


### PR DESCRIPTION
### What

Error on container restart (Windows 11 + WSL2 + Docker Desktop):

>`Xlib.error.DisplayConnectionError: Can't connect to display ":0": [Errno 111] Connection refused`

### Fix

Remove stale X lock file on container restart

----

### Extra

- entrypoint: Add logging on settings.json to match cookies.jar
- README: Add `?scale=true` to `novnc_lite.html` example
- docker-compose: Add `TZ` example